### PR TITLE
Use TOKEN secret for registry login

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.TOKEN }}
 
     - name: Extract metadata
       id: meta


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to authenticate with the TOKEN secret when logging into the registry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e21e6112f08325af32fac8a668b051