### PR TITLE
Fix workflow bundle copy recursion issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,8 +194,8 @@ jobs:
         # Create production directory
         mkdir -p n8n-bundle
         
-        # Copy the ENTIRE built project INCLUDING node_modules
-        cp -r . n8n-bundle/
+        # Copy the ENTIRE built project INCLUDING node_modules without recursing into the bundle itself
+        tar -cf - --exclude='./n8n-bundle' . | (cd n8n-bundle && tar -xf -)
         
         # Clean up development files we don't need in production
         rm -rf n8n-bundle/.git


### PR DESCRIPTION
## Summary
- replace the production bundle copy step with a tar pipeline to avoid copying the directory into itself

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68e4fef7452c832586567c64963d2627